### PR TITLE
updating to 0.15 and fixing overflow_bug

### DIFF
--- a/benchmarking-cli/src/utils_input.rs
+++ b/benchmarking-cli/src/utils_input.rs
@@ -12,7 +12,6 @@ use miden_vm::{
 pub struct Outputs {
     pub stack_output: Vec<u64>,
     pub trace_len: Option<usize>,
-    pub overflow_addrs: Option<Vec<u64>>,
     pub proof: Option<Vec<u8>>,
 }
 
@@ -247,7 +246,6 @@ fn test_parse_output() {
     let output_str: &str = r#"
     {
         "stack_output": [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        "overflow_addrs": [0, 1],
         "trace_len": 1024
     }"#;
 
@@ -260,5 +258,4 @@ fn test_parse_output() {
         output.stack(),
         vec![3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     );
-    assert_eq!(output.overflow_addrs(), vec![0, 1]);
 }

--- a/examples/provable_compliance.masm
+++ b/examples/provable_compliance.masm
@@ -26,7 +26,7 @@ begin
         # Check if the first entry is equal to the target account ID
         # If the target account ID is within the list of sanctioned addresses,
         # the program will stop and return the error code 666
-        eq assertz.err=666
+        eq assertz.err="sanctioned address"
     end
 
     # The program didn't stop, so the target account ID is not within the

--- a/playground/miden-wasm/Cargo.toml
+++ b/playground/miden-wasm/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-assembly = { package = "miden-assembly", version = "0.13.2", default-features = false }
+assembly = { package = "miden-assembly", version = "0.15.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-miden-air = { package = "miden-air", version = "0.13.2", default-features = false }
-miden-vm = { package = "miden-vm", version = "0.13.2", default-features = false }
-miden-stdlib = { package = "miden-stdlib", version = "0.13.2", default-features = false }
-miden-processor = { package = "miden-processor", version = "0.13.2", default-features = false }
+miden-air = { package = "miden-air", version = "0.15.0", default-features = false }
+miden-vm = { package = "miden-vm", version = "0.15.0", default-features = false }
+miden-stdlib = { package = "miden-stdlib", version = "0.15.0", default-features = false }
+miden-processor = { package = "miden-processor", version = "0.15.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde-wasm-bindgen = "0.4"

--- a/playground/miden-wasm/src/utils_debug.rs
+++ b/playground/miden-wasm/src/utils_debug.rs
@@ -1,9 +1,11 @@
 use crate::utils_input::Inputs;
 use crate::utils_program::{MidenProgram, DEBUG_ON};
 use miden_vm::{VmState, VmStateIterator, DefaultHost, MemAdviceProvider};
+use miden_processor::{SourceManager, DefaultSourceManager};
 use wasm_bindgen::prelude::*;
 use alloc::string::String;
 use alloc::vec::Vec;
+use alloc::sync::Arc;
 
 // This is the main struct that will be exported to JS
 // It will be used to execute debug commands against the VM
@@ -53,10 +55,14 @@ impl DebugExecutor {
 
         let mut host = DefaultHost::new(MemAdviceProvider::from(inputs.advice_provider));
 
+        let source_manager = Arc::new(DefaultSourceManager::default()) as Arc<dyn SourceManager>;
+
+
         let mut vm_state_iter = miden_vm::execute_iter(
             &program.program.unwrap(),
             inputs.stack_inputs,
             &mut host,
+            source_manager,
         );
 
         let vm_state = vm_state_iter
@@ -153,7 +159,7 @@ impl DebugExecutor {
     fn vm_state_to_output(&self) -> DebugOutput {
         let mut memory: Vec<(u64, u64)> = Vec::new();
         for &(address, mem) in self.vm_state.memory.iter() {
-            memory.push((address, mem.as_int()))
+            memory.push((u32::from(address) as u64, mem.as_int()))
         };
         println!("mem_interal: {:?}", memory);
 

--- a/playground/miden-wasm/src/utils_input.rs
+++ b/playground/miden-wasm/src/utils_input.rs
@@ -19,7 +19,6 @@ const SIMPLE_SMT_DEPTH: u8 = u64::BITS as u8;
 pub struct Outputs {
     pub stack_output: Vec<u64>,
     pub trace_len: Option<usize>,
-    pub overflow_addrs: Option<Vec<u64>>,
     pub proof: Option<Vec<u8>>,
 }
 

--- a/playground/src/components/DropDown.tsx
+++ b/playground/src/components/DropDown.tsx
@@ -11,7 +11,7 @@ const examples = [
   //'game_of_life_4x4',
   'catalan',
   'dft',
-  'shamir_secret_share',
+  //'shamir_secret_share',
   'provable_compliance',
   'collatz',
   'comparison',

--- a/playground/src/markdown/Explainer.md
+++ b/playground/src/markdown/Explainer.md
@@ -85,18 +85,17 @@ Want to know more? [Here](https://0xmiden.github.io/miden-vm/user_docs/assembly/
 ```json
 {
   "stack_output": [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-  "overflow_addrs": [0, 1],
   "trace_len": 1024
 }
 ```
 
-The `stack_output` represents our final state. The `overflow_addrs` is needed to reconstruct the state the is not shown in the `stack_output`.
+The `stack_output` represents our final state of the stack.
 
 The **trace_len** tells you how complex the computation is - it is the length of the execution trace. We need to always have an execution trace that is a power of 2 and >1024.
 
 The Outputs must also be a valid JSON (if you want to verify) and it can only contain numbers.
 
-You can also test the VM by proving a program and tampering with the Outputs. See if you can still verify the set of (`operand_stack`, `code`, `stack_output` and `overflow_addrs`)
+You can also test the VM by proving a program and tampering with the Outputs. See if you can still verify the set of (`operand_stack`, `code`, and `stack_output`)
 
 Want to know more? [Here](https://0xmiden.github.io/miden-vm/user_docs/assembly/main.html).
 
@@ -172,4 +171,4 @@ You need to prove before you can verify.
 ![](https://github.com/gubloon/examples/assets/7201911/da4cbff7-aa43-44fa-b8ad-158debf77e58)
 *On mobile, the option appears on top of the code editor, next to the "prove" option.*
 
-Here you can verify that the given `operand_stack` and `code` produce indeed the given `stack_output` and `overflow_addrs`. Verify will verify a previously generated proof of execution for a given program. For the verification the proof is needed.
+Here you can verify that the given `operand_stack` and `code` produce indeed the given `stack_output`. Verify will verify a previously generated proof of execution for a given program. For the verification the proof is needed.

--- a/playground/src/pages/proveWorker.js
+++ b/playground/src/pages/proveWorker.js
@@ -5,15 +5,26 @@ onmessage = async function (e) {
 
   try {
     await init();
+
     const {
       program_hash,
       cycles,
       stack_output,
       trace_len,
-      overflow_addrs,
       proof
     } = prove_program(code, inputs);
-    const overflow = overflow_addrs ? overflow_addrs.toString() : '[]';
+
+    // Helper to convert BigInt to number safely
+    const bigintToNumber = (x) =>
+      typeof x === 'bigint' ? Number(x) : x;
+
+    // Ensure stack_output is a standard array with numbers
+    const formattedStackOutput = Array.from(stack_output ?? []).map(bigintToNumber);
+
+    const outputObj = {
+      stack_output: formattedStackOutput,
+      trace_len: trace_len
+    };
 
     postMessage({
       success: true,
@@ -23,13 +34,9 @@ onmessage = async function (e) {
           cycles,
           trace_len
         },
-        output: `{
-            "stack_output" : [${stack_output.toString()}],
-            "overflow_addrs" : [${overflow}],
-            "trace_len" : ${trace_len}
-          }`,
+        output: JSON.stringify(outputObj, null, 2),
         proof,
-        stackOutput: stack_output.toString()
+        stackOutput: formattedStackOutput.toString()
       }
     });
   } catch (error) {

--- a/playground/src/utils/helper_functions.tsx
+++ b/playground/src/utils/helper_functions.tsx
@@ -168,7 +168,6 @@ export const formatBeautifyNumbersArray = (inputString: any) => {// eslint-disab
 
 const outputSchema = yup.object().shape({
   stack_output: yup.array().of(yup.number().integer().min(0)).required(),
-  overflow_addrs: yup.array().of(yup.number().integer().min(0)).notRequired(),
   trace_len: yup.number().integer().min(0).optional()
 });
 


### PR DESCRIPTION
This PR updates to Miden-VM 0.15 and it removes the `overflow_addr` from the `Outputs`. 