### PR TITLE
Fix Std Example

### DIFF
--- a/examples/standard_library.masm
+++ b/examples/standard_library.masm
@@ -7,11 +7,11 @@ use.std::math::u64
 
 begin
   # push the low limb then the high limb. b = 4294967296
-  push.0.1
+  push.2.5
   # push the low limb then the high limb. a = 4294967299
   push.3.1
 
-  # 3.1 is bigger than 0.1
+  # 5.2 is bigger than 1.3
   exec.u64::max
 
   # truncate stack to end with less than 16 elements


### PR DESCRIPTION
The case in the original example is a false positive. Since it pushes the low limb first, then the high limb, the result is correct because "1.3 is bigger than 1.0", and not "3.1 is bigger than 0.1".

So, the better example would be to show the high limb on the right of the stack is bigger than the left of the stack.